### PR TITLE
Endpoints name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eryxcoop/appyx-comm",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Paquete de comunicación web",
   "main": "index.js",
   "source": "index.js",

--- a/src/endpoints/Endpoint.js
+++ b/src/endpoints/Endpoint.js
@@ -150,6 +150,10 @@ export default class Endpoint {
     return this.ownResponses().concat(this.generalResponses())
   }
 
+  get name() {
+    return `${this.method()} ${this.url()}`
+  }
+
   url() {
     return this._url;
   }

--- a/src/requester/FakeRequester.js
+++ b/src/requester/FakeRequester.js
@@ -8,11 +8,11 @@ export default class FakeRequester extends Requester {
   }
 
   addResponseFor({endpoint, response}) {
-    this._expectedResponses[endpoint.constructor.name] = response;
+    this._expectedResponses[endpoint.name] = response;
   }
 
   _getResponseClassFor(endpoint) {
-    return this._expectedResponses[endpoint.constructor.name];
+    return this._expectedResponses[endpoint.name];
   }
 
   _getExpectedResponseFor(endpoint) {

--- a/test/errorHandling.test.js
+++ b/test/errorHandling.test.js
@@ -72,8 +72,16 @@ function dummyRequesterExpectingAuthenticationErrorResponse() {
   return requester;
 }
 
-function endpointWithResponses(responses, url= 'example') {
+function getEndpointWithResponses(responses, url = 'example') {
   return Endpoint.newGet({
+    url: url,
+    ownResponses: responses,
+    needsAuthorization: false,
+  });
+}
+
+function postEndpointWithResponses(responses, url = 'example') {
+  return Endpoint.newPost({
     url: url,
     ownResponses: responses,
     needsAuthorization: false,
@@ -331,7 +339,7 @@ test('When fake requester is used default response is returned', async () => {
   const apiClient = new ApiClient(requester);
 
   // I can create a get endpoint
-  const getEndpoint = endpointWithResponses([TestSuccessfulApiResponse]);
+  const getEndpoint = getEndpointWithResponses([TestSuccessfulApiResponse]);
 
   const customResponseHandler = new ApiResponseHandler(
     {
@@ -353,7 +361,7 @@ test('When using fake requester default response can be overwritten', async () =
   const apiClient = new ApiClient(requester);
 
   // I can create a get endpoint
-  const getEndpoint = endpointWithResponses([TestSuccessfulApiResponse]);
+  const getEndpoint = getEndpointWithResponses([TestSuccessfulApiResponse]);
 
   requester.addResponseFor({endpoint: getEndpoint, response: AnotherTestSuccessfulApiResponse});
 
@@ -377,8 +385,33 @@ test('When using fake requester only endpoint added to Fakerequester is overwrit
   const apiClient = new ApiClient(requester);
 
   // I can create two get endpoint
-  const getEndpoint = endpointWithResponses([TestSuccessfulApiResponse]);
-  const getAnotherEndpoint = endpointWithResponses([TestSuccessfulApiResponse], 'another-example');
+  const getEndpoint = getEndpointWithResponses([TestSuccessfulApiResponse], 'example-url');
+  const getAnotherEndpoint = getEndpointWithResponses([TestSuccessfulApiResponse], 'another-example-url');
+
+  requester.addResponseFor({endpoint: getAnotherEndpoint, response: AnotherTestSuccessfulApiResponse});
+
+  const customResponseHandler = new ApiResponseHandler(
+    {
+      handlesSuccess: (response, request) => {
+        return response.response();
+      }
+    }
+  );
+
+  const response = await apiClient.callEndpoint(getEndpoint, {}, customResponseHandler);
+
+  // Then the response is handled by the custom response handler
+  expect(response).toBe(TestSuccessfulApiResponse.defaultResponse());
+});
+
+test('When using fake requester for endpoint with same url only the clarified method is overwritten', async () => {
+  // Given a client
+  const requester = new FakeRequester({waitingTime: 0});
+  const apiClient = new ApiClient(requester);
+
+  // I can create two get endpoint
+  const getEndpoint = getEndpointWithResponses([TestSuccessfulApiResponse], 'example-url');
+  const getAnotherEndpoint = postEndpointWithResponses([TestSuccessfulApiResponse], 'example-url');
 
   requester.addResponseFor({endpoint: getAnotherEndpoint, response: AnotherTestSuccessfulApiResponse});
 


### PR DESCRIPTION
# Changes
Now endpoints can be used in fakeRequester even if they are created from constructor. 
Before all of them were named the same, so it would change response for all of them.